### PR TITLE
Create route to receive steps

### DIFF
--- a/collab/src/index.ts
+++ b/collab/src/index.ts
@@ -1,4 +1,5 @@
 import type { Request, Response } from "express";
+/* eslint "import/no-named-as-default-member": "off" -- This is the only way I can see to avoid a warning about the (correct) way express is imported below */
 import express from 'express';
 
 const app = express();


### PR DESCRIPTION
## What does this change?

Creates a new endpoint which will accept prosemirror editor steps. At the moment it just expects a JSON blob, which it then logs. This will unblock client side development. We can add persistence later

The endpoint is `/documents/:documentId/steps`. This is not identical to the example server in the Prosemirror code. I've chosen to use the word `steps` where they use `events`. They are called `steps` in most places, and it is easier to be consistent and specific in our naming. Events could mean other things (e.g. when an article is published or taken down).

## How to test

I have tested this locally by running 

`curl -v "http://localhost:3000/documents/1234/steps" -X POST -d '{"foo": 1}' -H "Content-Type: application/json"`

and seeing logs.

Since this project is very new, I don't think there is much value in the reviewer also testing this. But feedback on the code is welcome.

