### PR TITLE
Add initial Postgres DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,16 @@ or for live updates
 ```bash
 npm run test-watch
 ```
+
+#### Architecture
+
+The Node server runs on an EC2 instance. We persist edit history steps in an RDS managed Postgres database. 
+
+```mermaid
+flowchart
+    N["Node Server \n <i>EC2</i>"]
+    P[("Postgres DB \n <i>RDS</i>")]
+    subgraph VPC
+        N --persists edit history--> P
+    end
+```

--- a/cdk/lib/__snapshots__/editorial-collaboration.test.ts.snap
+++ b/cdk/lib/__snapshots__/editorial-collaboration.test.ts.snap
@@ -25,6 +25,9 @@ exports[`The EditorialCollaboration stack matches the snapshot 1`] = `
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
       "GuCname",
+      "GuSecurityGroup",
+      "GuSubnetListParameter",
+      "GuDatabaseInstance",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -53,6 +56,11 @@ exports[`The EditorialCollaboration stack matches the snapshot 1`] = `
       "Default": "/account/services/logging.stream.name",
       "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
       "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "PrivateSubnets": {
+      "Default": "/account/vpc/primary/subnets/private",
+      "Description": "A list of private subnets",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
     },
     "VpcId": {
       "Default": "/account/vpc/primary/id",
@@ -173,6 +181,201 @@ exports[`The EditorialCollaboration stack matches the snapshot 1`] = `
       "Type": "AWS::CertificateManager::Certificate",
       "UpdateReplacePolicy": "Retain",
     },
+    "DBSecurityGroupEditorialcollaborationDF4493EF": {
+      "Properties": {
+        "GroupDescription": "Allow traffic from EC2 instance to DB",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "255.255.255.255/32",
+            "Description": "Disallow all traffic",
+            "FromPort": 252,
+            "IpProtocol": "icmp",
+            "ToPort": 86,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "editorial-collaboration",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/editorial-collaboration",
+          },
+          {
+            "Key": "Stack",
+            "Value": "composer",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "DBSecurityGroupEditorialcollaborationfromEditorialCollaborationGuHttpsEgressSecurityGroupEditorialcollaborationB5107FA954322A46C402": {
+      "Properties": {
+        "Description": "Allow connections from EC2 instance to DB",
+        "FromPort": 5432,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "DBSecurityGroupEditorialcollaborationDF4493EF",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "GuHttpsEgressSecurityGroupEditorialcollaborationB5EB9593",
+            "GroupId",
+          ],
+        },
+        "ToPort": 5432,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "DBSecurityGroupEditorialcollaborationfromEditorialCollaborationWazuhSecurityGroup4E797D24543266AFA3F2": {
+      "Properties": {
+        "Description": "Allow connections from EC2 instance to DB",
+        "FromPort": 5432,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "DBSecurityGroupEditorialcollaborationDF4493EF",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "ToPort": 5432,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "DBSubnetGroup": {
+      "Properties": {
+        "DBSubnetGroupDescription": "Subnet for editorial collaboration database",
+        "SubnetIds": {
+          "Ref": "PrivateSubnets",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/editorial-collaboration",
+          },
+          {
+            "Key": "Stack",
+            "Value": "composer",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::RDS::DBSubnetGroup",
+    },
+    "DatabaseEditorialcollaborationdbCCA6A1A0": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AllocatedStorage": "150",
+        "AllowMajorVersionUpgrade": false,
+        "AutoMinorVersionUpgrade": true,
+        "CopyTagsToSnapshot": true,
+        "DBInstanceClass": "db.t4g.micro",
+        "DBInstanceIdentifier": "editorial-collaboration-db-test",
+        "DBSubnetGroupName": {
+          "Ref": "DBSubnetGroup",
+        },
+        "DeleteAutomatedBackups": false,
+        "DeletionProtection": true,
+        "EnableIAMDatabaseAuthentication": true,
+        "Engine": "postgres",
+        "EngineVersion": "16.2",
+        "MasterUserPassword": {
+          "Fn::Join": [
+            "",
+            [
+              "{{resolve:secretsmanager:",
+              {
+                "Ref": "EditorialCollaborationDatabaseEditorialcollaborationdbSecretD7DDFB6E3fdaad7efa858a3daf9490cf0a702aeb",
+              },
+              ":SecretString:password::}}",
+            ],
+          ],
+        },
+        "MasterUsername": "editorial_collaboration",
+        "MultiAZ": false,
+        "Port": "5432",
+        "PreferredMaintenanceWindow": "Mon:06:30-Mon:07:00",
+        "PubliclyAccessible": false,
+        "StorageEncrypted": true,
+        "StorageType": "gp2",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "editorial-collaboration-db",
+          },
+          {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/editorial-collaboration",
+          },
+          {
+            "Key": "Stack",
+            "Value": "composer",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VPCSecurityGroups": [
+          {
+            "Fn::GetAtt": [
+              "DBSecurityGroupEditorialcollaborationDF4493EF",
+              "GroupId",
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::RDS::DBInstance",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "DatabaseEditorialcollaborationdbSecretAttachment6AF09E4C": {
+      "Properties": {
+        "SecretId": {
+          "Ref": "EditorialCollaborationDatabaseEditorialcollaborationdbSecretD7DDFB6E3fdaad7efa858a3daf9490cf0a702aeb",
+        },
+        "TargetId": {
+          "Ref": "DatabaseEditorialcollaborationdbCCA6A1A0",
+        },
+        "TargetType": "AWS::RDS::DBInstance",
+      },
+      "Type": "AWS::SecretsManager::SecretTargetAttachment",
+    },
     "DescribeEC2PolicyFF5F9295": {
       "Properties": {
         "PolicyDocument": {
@@ -215,6 +418,56 @@ exports[`The EditorialCollaboration stack matches the snapshot 1`] = `
         "TTL": 3600,
       },
       "Type": "Guardian::DNS::RecordSet",
+    },
+    "EditorialCollaborationDatabaseEditorialcollaborationdbSecretD7DDFB6E3fdaad7efa858a3daf9490cf0a702aeb": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "Description": {
+          "Fn::Join": [
+            "",
+            [
+              "Generated by the CDK for stack: ",
+              {
+                "Ref": "AWS::StackName",
+              },
+            ],
+          ],
+        },
+        "GenerateSecretString": {
+          "ExcludeCharacters": " %+~\`#$&*()|[]{}:;<>?!'/@"\\",
+          "GenerateStringKey": "password",
+          "PasswordLength": 30,
+          "SecretStringTemplate": "{"username":"editorial_collaboration"}",
+        },
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "editorial-collaboration-db",
+          },
+          {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/editorial-collaboration",
+          },
+          {
+            "Key": "Stack",
+            "Value": "composer",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SecretsManager::Secret",
+      "UpdateReplacePolicy": "Delete",
     },
     "GetDistributablePolicyEditorialcollaboration7454A93E": {
       "Properties": {
@@ -308,6 +561,27 @@ exports[`The EditorialCollaboration stack matches the snapshot 1`] = `
         "ToPort": 3000,
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "GuHttpsEgressSecurityGroupEditorialcollaborationtoEditorialCollaborationDBSecurityGroupEditorialcollaboration37E069605432BBE81FC9": {
+      "Properties": {
+        "Description": "Allow connections from EC2 instance to DB",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "DBSecurityGroupEditorialcollaborationDF4493EF",
+            "GroupId",
+          ],
+        },
+        "FromPort": 5432,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "GuHttpsEgressSecurityGroupEditorialcollaborationB5EB9593",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 5432,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
     },
     "GuLogShippingPolicy981BFE5A": {
       "Properties": {
@@ -760,6 +1034,27 @@ exports[`The EditorialCollaboration stack matches the snapshot 1`] = `
         "ToPort": 3000,
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "WazuhSecurityGrouptoEditorialCollaborationDBSecurityGroupEditorialcollaboration37E069605432CE28DD4A": {
+      "Properties": {
+        "Description": "Allow connections from EC2 instance to DB",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "DBSecurityGroupEditorialcollaborationDF4493EF",
+            "GroupId",
+          ],
+        },
+        "FromPort": 5432,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 5432,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
     },
     "composerTESTeditorialcollaborationF4717F5D": {
       "DependsOn": [

--- a/cdk/lib/editorial-collaboration.ts
+++ b/cdk/lib/editorial-collaboration.ts
@@ -3,9 +3,17 @@ import { AccessScope } from '@guardian/cdk/lib/constants';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
+import { GuSecurityGroup, GuVpc } from '@guardian/cdk/lib/constructs/ec2';
+import { GuDatabaseInstance } from '@guardian/cdk/lib/constructs/rds';
 import type { App } from 'aws-cdk-lib';
-import { Duration } from 'aws-cdk-lib';
-import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
+import { Duration, aws_rds as rds, RemovalPolicy } from 'aws-cdk-lib';
+import {
+	InstanceClass,
+	InstanceSize,
+	InstanceType,
+	Port,
+} from 'aws-cdk-lib/aws-ec2';
+import { SubnetGroup } from 'aws-cdk-lib/aws-rds';
 
 interface EditorialCollaborationProps extends GuStackProps {
 	domainName: string;
@@ -18,11 +26,15 @@ export class EditorialCollaboration extends GuStack {
 		const { domainName, stage } = props;
 
 		const appName = 'editorial-collaboration';
+		const appPort = 3000;
 
-		const guPlayApp = new GuEc2App(this, {
+		const dbUsername = 'editorial_collaboration';
+		const dbPort = 5432;
+
+		const guEc2App = new GuEc2App(this, {
 			access: { scope: AccessScope.PUBLIC },
 			app: appName,
-			applicationPort: 3000,
+			applicationPort: appPort,
 			certificateProps: {
 				domainName,
 			},
@@ -67,7 +79,52 @@ systemctl start ${appName}
 			app: appName,
 			domainName: domainName,
 			ttl: Duration.hours(1),
-			resourceRecord: guPlayApp.loadBalancer.loadBalancerDnsName,
+			resourceRecord: guEc2App.loadBalancer.loadBalancerDnsName,
+		});
+
+		const dbAccessSecurityGroup = new GuSecurityGroup(this, 'DBSecurityGroup', {
+			app: appName,
+			description: 'Allow traffic from EC2 instance to DB',
+			vpc: guEc2App.vpc,
+			allowAllOutbound: false,
+		});
+
+		dbAccessSecurityGroup.connections.allowFrom(
+			guEc2App.autoScalingGroup,
+			Port.tcp(dbPort),
+			'Allow connections from EC2 instance to DB',
+		);
+
+		new GuDatabaseInstance(this, 'Database', {
+			app: `${appName}-db`,
+			instanceIdentifier: `${appName}-db-${stage}`,
+			instanceType: 'db.t4g.micro',
+			engine: rds.DatabaseInstanceEngine.postgres({
+				version: rds.PostgresEngineVersion.VER_16_2,
+			}),
+			vpc: guEc2App.vpc,
+			subnetGroup: new SubnetGroup(this, 'DBSubnetGroup', {
+				vpc: guEc2App.vpc,
+				vpcSubnets: {
+					subnets: GuVpc.subnetsFromParameter(this),
+				},
+				description: 'Subnet for editorial collaboration database',
+			}),
+			port: dbPort,
+			preferredMaintenanceWindow: 'Mon:06:30-Mon:07:00',
+			credentials: rds.Credentials.fromGeneratedSecret(dbUsername),
+			iamAuthentication: true,
+			storageType: rds.StorageType.GP2, // SSD
+			allocatedStorage: 150,
+			storageEncrypted: true,
+			multiAz: stage === 'PROD',
+			publiclyAccessible: false,
+			removalPolicy: RemovalPolicy.RETAIN,
+			securityGroups: [dbAccessSecurityGroup],
+			devXBackups: { enabled: true },
+			allowMajorVersionUpgrade: false,
+			autoMinorVersionUpgrade: true,
+			deleteAutomatedBackups: false,
 		});
 	}
 }


### PR DESCRIPTION
## What does this change?
Adds an RDS managed Postgres instance to persist Edit History steps sent from the collab server:

```mermaid
flowchart
    N["Node Server \n <i>EC2</i>"]
    P[("Postgres DB \n <i>RDS</i>")]
    subgraph VPC
        N --persists edit history--> P
    end
```

This PR only provides the infrastructure - there is no implementation to hook the back end up to the database.

The DB is locked down to the same VPC as the EC2 app, and security groups are used to grant access from the EC2 app to the DB. 

### How to test

I have deployed this to CODE and the cloudformation has synthesised successfully. You can inspect the RDS instance in the AWS account for Composer, under `RDS` -> `Databases` -> `editorial-collaboration-db-code`. 

Here you can find the RDS endpoint, under the `Connectivity & security` tab. The `Configuration` tab should confirm choices made in the CDK definition (for RAM, Storage type, etc.).

To test connectivity from the EC2 app to the RDS instance:
1. Obtain Composer credenetials from Janus
2. Use `ssm` to connect to the EC2 app: `ssm ssh -t editorial-collaboration,CODE --profile composer -x --newest`
(if you need to install `ssm`, see https://github.com/guardian/ssm-scala)
3. Inside the EC2 instance, run `nc -zv RDS_ENDPOINT 5432`, replacing RDS_ENDPOINT with the endpoint. This should return `Connection to RDS_ENDPOINT 5432 port [tcp/postgresql] succeeded!`. If you run this same command on your local machine, it should return `nc: connectx to RDS_ENDPOINT port 5432 (tcp) failed: Operation timed out`. 

This should increase confidence that connections are locked down between the EC2 app and the RDS instance.