### PR TITLE
Bundle server.ts as the entrypoint

### DIFF
--- a/collab/prod.config.js
+++ b/collab/prod.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    entry: './src/index.ts',
+    entry: './src/server.ts',
     mode: 'production',
     target: 'node',
     module: {


### PR DESCRIPTION
## What does this change?
While rejigging the express routing logic around to make testing easier in https://github.com/guardian/editorial-collaboration/pull/4, we changed the entrypoint of the app to be `server.ts` rather than `index.ts`. 

We reflected this in the start script (now `ts-node src/server.ts`), but the webpack config was still bundling with the old entrypoint (`index.ts`). As a result subsequent deploys to main have been failing.

## How to test
This branch has been deployed and remains healthy.

## How can we measure success?
Unblocks work on #10, #11 etc.