### PR TITLE
Provide stage for Panda config lookup

### DIFF
--- a/cdk/lib/__snapshots__/editorial-collaboration.test.ts.snap
+++ b/cdk/lib/__snapshots__/editorial-collaboration.test.ts.snap
@@ -879,6 +879,7 @@ ExecStart=/usr/bin/node /editorial-collaboration/main.js
 Restart=always
 StandardOutput=journal
 StandardError=journal
+Environment=STAGE=TEST
 User=editorial-collaboration
 Group=editorial-collaboration
 [Install]

--- a/cdk/lib/editorial-collaboration.ts
+++ b/cdk/lib/editorial-collaboration.ts
@@ -15,7 +15,7 @@ export class EditorialCollaboration extends GuStack {
 	constructor(scope: App, id: string, props: EditorialCollaborationProps) {
 		super(scope, id, props);
 
-		const { domainName } = props;
+		const { domainName, stage } = props;
 
 		const appName = 'editorial-collaboration';
 
@@ -45,6 +45,7 @@ ExecStart=/usr/bin/node /${appName}/main.js
 Restart=always
 StandardOutput=journal
 StandardError=journal
+Environment=STAGE=${stage}
 User=${appName}
 Group=${appName}
 [Install]


### PR DESCRIPTION
## What does this change?

In #9, we added Panda middleware which relied on a stage-specific config. This in turn is derived from an environment variable which we forgot to include. This PR defines an environment variable for the Stage in the SystemD boot script.

Before, the Panda middleware only worked locally, and not on CODE or PROD (it would always return 403, even when the correct cookie was present). Now the Panda middleware should authenticate properly on CODE and PROD.

## How to test

I have deployed this to CODE (admittedly as part of #10, as I can't tear down the Postgres DB deployed to CODE). It now works successfully - you should be able to test for yourself by visiting https://editorial-collaboration.code.dev-gutools.co.uk/ with a valid CODE Panda cookie.
