### PR TITLE
Add cors headers to collab app

### DIFF
--- a/collab/src/index.ts
+++ b/collab/src/index.ts
@@ -1,14 +1,29 @@
 /* eslint-disable @typescript-eslint/no-misused-promises -- fixes middleware linting warning, which is a known issue with Express typings, see: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/50871*/
-import type { Request, Response } from "express";
+import type { NextFunction, Request, Response } from 'express';
 /* eslint "import/no-named-as-default-member": "off" -- This is the only way I can see to avoid a warning about the (correct) way express is imported below */
 import express from 'express';
-import {parseSteps} from "./lib/parse-steps";
-import {authMiddleware} from "./middleware/auth-middleware";
-import type { Json } from "./types/json";
+import { parseSteps } from './lib/parse-steps';
+import { authMiddleware } from './middleware/auth-middleware';
+import type { Json } from './types/json';
 
 export const app = express();
 
-app.use(express.json())
+app.use(express.json());
+
+app.use((req: Request, res: Response, next: NextFunction) => {
+  const host = req.get('origin') ?? '';
+  if (
+    host.endsWith('.gutools.co.uk') ||
+    host.endsWith('.dev-gutools.co.uk')
+  ) {
+    res.header('Access-Control-Allow-Headers', 'Content-Type');
+    res.header('Access-Control-Allow-Origin', host);
+    res.header('Access-Control-Allow-Methods', 'OPTIONS,POST,GET');
+    res.header('Access-Control-Allow-Credentials', 'true');
+    res.header('Access-Control-Max-Age', '86400');
+  }
+  next();
+});
 
 app.get('/', authMiddleware, (req: Request, res: Response) => {
     res.send('Hello World!');


### PR DESCRIPTION
## What does this change?

This adds CORS headers to the express app powering edit history/collaborative editing to allow it to communicate with Composer.