### PR TITLE
Only require ssl for CODE/PROD db connections

### DIFF
--- a/collab/src/lib/database.ts
+++ b/collab/src/lib/database.ts
@@ -77,11 +77,6 @@ class Database {
       .then((sql: Sql) => sql`INSERT INTO step ${ sql(values) }`)
       .catch(err => console.error(err)) // TODO: logging/alerting
   };
-
-  public getSteps = async (id: string) => {
-    return await this.connect()
-      .then((sql: Sql) => sql`SELECT content FROM step WHERE id = id`);
-  }
 }
 
 const database = new Database();


### PR DESCRIPTION
## What does this change?
`ssl: 'require'` is needed to connect to CODE/PROD databases, but breaks the connection to the local Docker DB.
