### PR TITLE
Bump aws dependencies to resolve high vulnerabilities

### DIFF
--- a/collab/package-lock.json
+++ b/collab/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aws-sdk/client-secrets-manager": "^3.995.0",
-        "@aws-sdk/credential-providers": "^3.995.0",
+        "@aws-sdk/client-secrets-manager": "^3.1017.0",
+        "@aws-sdk/credential-providers": "^3.1017.0",
         "cors": "^2.8.5",
         "express": "^4.22.1",
         "postgres": "^3.4.4",
@@ -257,47 +257,47 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.1008.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.1008.0.tgz",
-      "integrity": "sha512-zzHnrTImR1JJ/Sq90y35UiFiriwge6W8qZQxIBJCgAMwEGkQAqHEAc3d6ptLmwdntcid3dx7wvauOXbpiMVbAQ==",
+      "version": "3.1017.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.1017.0.tgz",
+      "integrity": "sha512-6bDSefNF53Tt2e/nzighWQbye80chPMoo3FG3L6bEjcyRFROl1cs8RlvJ529cpHo94pNot35gu5Wpg3sENyuXg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.19",
-        "@aws-sdk/credential-provider-node": "^3.972.20",
-        "@aws-sdk/middleware-host-header": "^3.972.7",
-        "@aws-sdk/middleware-logger": "^3.972.7",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
-        "@aws-sdk/middleware-user-agent": "^3.972.20",
-        "@aws-sdk/region-config-resolver": "^3.972.7",
-        "@aws-sdk/types": "^3.973.5",
-        "@aws-sdk/util-endpoints": "^3.996.4",
-        "@aws-sdk/util-user-agent-browser": "^3.972.7",
-        "@aws-sdk/util-user-agent-node": "^3.973.6",
-        "@smithy/config-resolver": "^4.4.10",
-        "@smithy/core": "^3.23.9",
-        "@smithy/fetch-http-handler": "^5.3.13",
-        "@smithy/hash-node": "^4.2.11",
-        "@smithy/invalid-dependency": "^4.2.11",
-        "@smithy/middleware-content-length": "^4.2.11",
-        "@smithy/middleware-endpoint": "^4.4.23",
-        "@smithy/middleware-retry": "^4.4.40",
-        "@smithy/middleware-serde": "^4.2.12",
-        "@smithy/middleware-stack": "^4.2.11",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/node-http-handler": "^4.4.14",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/smithy-client": "^4.12.3",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.11",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/credential-provider-node": "^3.972.25",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.25",
+        "@aws-sdk/region-config-resolver": "^3.972.9",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.11",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.27",
+        "@smithy/middleware-retry": "^4.4.44",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.39",
-        "@smithy/util-defaults-mode-node": "^4.2.42",
-        "@smithy/util-endpoints": "^3.3.2",
-        "@smithy/util-middleware": "^4.2.11",
-        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-defaults-mode-browser": "^4.3.43",
+        "@smithy/util-defaults-mode-node": "^4.2.47",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -372,47 +372,47 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1008.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1008.0.tgz",
-      "integrity": "sha512-9ZHAefH+yvpRhIs+zjQOmeGmze/5ed5BnuuEy/YUV2+6bi2CaQs4eqSi0mKgrYT9/q9Gh3Z9CJ0ZbZpYuXoxhA==",
+      "version": "3.1017.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1017.0.tgz",
+      "integrity": "sha512-QLzsg1+05NvGOl5RpN+s/Bf8Eh4vZ0x3mZW8FHz97lJ0oBUjRkzwAjlg3njSckN/rWU76t9NGDiLbPtTCGH9kg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.19",
-        "@aws-sdk/credential-provider-node": "^3.972.20",
-        "@aws-sdk/middleware-host-header": "^3.972.7",
-        "@aws-sdk/middleware-logger": "^3.972.7",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
-        "@aws-sdk/middleware-user-agent": "^3.972.20",
-        "@aws-sdk/region-config-resolver": "^3.972.7",
-        "@aws-sdk/types": "^3.973.5",
-        "@aws-sdk/util-endpoints": "^3.996.4",
-        "@aws-sdk/util-user-agent-browser": "^3.972.7",
-        "@aws-sdk/util-user-agent-node": "^3.973.6",
-        "@smithy/config-resolver": "^4.4.10",
-        "@smithy/core": "^3.23.9",
-        "@smithy/fetch-http-handler": "^5.3.13",
-        "@smithy/hash-node": "^4.2.11",
-        "@smithy/invalid-dependency": "^4.2.11",
-        "@smithy/middleware-content-length": "^4.2.11",
-        "@smithy/middleware-endpoint": "^4.4.23",
-        "@smithy/middleware-retry": "^4.4.40",
-        "@smithy/middleware-serde": "^4.2.12",
-        "@smithy/middleware-stack": "^4.2.11",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/node-http-handler": "^4.4.14",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/smithy-client": "^4.12.3",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.11",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/credential-provider-node": "^3.972.25",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.25",
+        "@aws-sdk/region-config-resolver": "^3.972.9",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.11",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.27",
+        "@smithy/middleware-retry": "^4.4.44",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.39",
-        "@smithy/util-defaults-mode-node": "^4.2.42",
-        "@smithy/util-endpoints": "^3.3.2",
-        "@smithy/util-middleware": "^4.2.11",
-        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-defaults-mode-browser": "^4.3.43",
+        "@smithy/util-defaults-mode-node": "^4.2.47",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -421,21 +421,21 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.19.tgz",
-      "integrity": "sha512-56KePyOcZnKTWCd89oJS1G6j3HZ9Kc+bh/8+EbvtaCCXdP6T7O7NzCiPuHRhFLWnzXIaXX3CxAz0nI5My9spHQ==",
+      "version": "3.973.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.24.tgz",
+      "integrity": "sha512-vvf82RYQu2GidWAuQq+uIzaPz9V0gSCXVqdVzRosgl5rXcspXOpSD3wFreGGW6AYymPr97Z69kjVnLePBxloDw==",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@aws-sdk/xml-builder": "^3.972.10",
-        "@smithy/core": "^3.23.9",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/signature-v4": "^5.3.11",
-        "@smithy/smithy-client": "^4.12.3",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/xml-builder": "^3.972.15",
+        "@smithy/core": "^3.23.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
         "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-middleware": "^4.2.12",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -457,14 +457,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.972.12.tgz",
-      "integrity": "sha512-0R7EKJBd19VGoYMrp7ozikwRh6KpapIO3T/Vf9tMrAVxrUNd5V+A6V1gxypY7iJv9GwVR1ZWL/nFt/m0KvcjIQ==",
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.972.17.tgz",
+      "integrity": "sha512-rMiW9GkLFBeRNvYdTzIRNP2Gq8vE8lomuqkv0BM7taX80UrN5oAa1wA8dDSWidga15k+0eFLo4RDsBHmeR1TUA==",
       "dependencies": {
-        "@aws-sdk/nested-clients": "^3.996.9",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/nested-clients": "^3.996.14",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -472,14 +472,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.17.tgz",
-      "integrity": "sha512-MBAMW6YELzE1SdkOniqr51mrjapQUv8JXSGxtwRjQV0mwVDutVsn22OPAUt4RcLRvdiHQmNBDEFP9iTeSVCOlA==",
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.22.tgz",
+      "integrity": "sha512-cXp0VTDWT76p3hyK5D51yIKEfpf6/zsUvMfaB8CkyqadJxMQ8SbEeVroregmDlZbtG31wkj9ei0WnftmieggLg==",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.19",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -487,19 +487,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.19.tgz",
-      "integrity": "sha512-9EJROO8LXll5a7eUFqu48k6BChrtokbmgeMWmsH7lBb6lVbtjslUYz/ShLi+SHkYzTomiGBhmzTW7y+H4BxsnA==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.24.tgz",
+      "integrity": "sha512-h694K7+tRuepSRJr09wTvQfaEnjzsKZ5s7fbESrVds02GT/QzViJ94/HCNwM7bUfFxqpPXHxulZfL6Cou0dwPg==",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.19",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/fetch-http-handler": "^5.3.13",
-        "@smithy/node-http-handler": "^4.4.14",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/smithy-client": "^4.12.3",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-stream": "^4.5.17",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.20",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -507,23 +507,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.19.tgz",
-      "integrity": "sha512-pVJVjWqVrPqjpFq7o0mCmeZu1Y0c94OCHSYgivdCD2wfmYVtBbwQErakruhgOD8pcMcx9SCqRw1pzHKR7OGBcA==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.24.tgz",
+      "integrity": "sha512-O46fFmv0RDFWiWEA9/e6oW92BnsyAXuEgTTasxHligjn2RCr9L/DK773m/NoFaL3ZdNAUz8WxgxunleMnHAkeQ==",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.19",
-        "@aws-sdk/credential-provider-env": "^3.972.17",
-        "@aws-sdk/credential-provider-http": "^3.972.19",
-        "@aws-sdk/credential-provider-login": "^3.972.19",
-        "@aws-sdk/credential-provider-process": "^3.972.17",
-        "@aws-sdk/credential-provider-sso": "^3.972.19",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.19",
-        "@aws-sdk/nested-clients": "^3.996.9",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/credential-provider-imds": "^4.2.11",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/credential-provider-env": "^3.972.22",
+        "@aws-sdk/credential-provider-http": "^3.972.24",
+        "@aws-sdk/credential-provider-login": "^3.972.24",
+        "@aws-sdk/credential-provider-process": "^3.972.22",
+        "@aws-sdk/credential-provider-sso": "^3.972.24",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.24",
+        "@aws-sdk/nested-clients": "^3.996.14",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -531,17 +531,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.19.tgz",
-      "integrity": "sha512-jOXdZ1o+CywQKr6gyxgxuUmnGwTTnY2Kxs1PM7fI6AYtDWDnmW/yKXayNqkF8KjP1unflqMWKVbVt5VgmE3L0g==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.24.tgz",
+      "integrity": "sha512-sIk8oa6AzDoUhxsR11svZESqvzGuXesw62Rl2oW6wguZx8i9cdGCvkFg+h5K7iucUZP8wyWibUbJMc+J66cu5g==",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.19",
-        "@aws-sdk/nested-clients": "^3.996.9",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/nested-clients": "^3.996.14",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -549,21 +549,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.20.tgz",
-      "integrity": "sha512-0xHca2BnPY0kzjDYPH7vk8YbfdBPpWVS67rtqQMalYDQUCBYS37cZ55K6TuFxCoIyNZgSCFrVKr9PXC5BVvQQw==",
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.25.tgz",
+      "integrity": "sha512-m7dR0Dsva2P+VUpL+VkC0WwiDby5pgmWXkRVDB5rlwv0jXJrQJf7YMtCoM8Wjk0H9jPeCYOxOXXcIgp/qp5Alg==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.17",
-        "@aws-sdk/credential-provider-http": "^3.972.19",
-        "@aws-sdk/credential-provider-ini": "^3.972.19",
-        "@aws-sdk/credential-provider-process": "^3.972.17",
-        "@aws-sdk/credential-provider-sso": "^3.972.19",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.19",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/credential-provider-imds": "^4.2.11",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/credential-provider-env": "^3.972.22",
+        "@aws-sdk/credential-provider-http": "^3.972.24",
+        "@aws-sdk/credential-provider-ini": "^3.972.24",
+        "@aws-sdk/credential-provider-process": "^3.972.22",
+        "@aws-sdk/credential-provider-sso": "^3.972.24",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.24",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -571,15 +571,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.17.tgz",
-      "integrity": "sha512-c8G8wT1axpJDgaP3xzcy+q8Y1fTi9A2eIQJvyhQ9xuXrUZhlCfXbC0vM9bM1CUXiZppFQ1p7g0tuUMvil/gCPg==",
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.22.tgz",
+      "integrity": "sha512-Os32s8/4gTZjBk5BtoS/cuTILaj+K72d0dVG7TCJX/fC4598cxwLDmf1AEHEpER5oL3K//yETjvFaz0V8oO5Xw==",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.19",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -587,17 +587,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.19.tgz",
-      "integrity": "sha512-kVjQsEU3b///q7EZGrUzol9wzwJFKbEzqJKSq82A9ShrUTEO7FNylTtby3sPV19ndADZh1H3FB3+5ZrvKtEEeg==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.24.tgz",
+      "integrity": "sha512-PaFv7snEfypU2yXkpvfyWgddEbDLtgVe51wdZlinhc2doubBjUzJZZpgwuF2Jenl1FBydMhNpMjD6SBUM3qdSA==",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.19",
-        "@aws-sdk/nested-clients": "^3.996.9",
-        "@aws-sdk/token-providers": "3.1008.0",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/nested-clients": "^3.996.14",
+        "@aws-sdk/token-providers": "3.1015.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -605,16 +605,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.19.tgz",
-      "integrity": "sha512-BV1BlTFdG4w4tAihxN7iXDBoNcNewXD4q8uZlNQiUrnqxwGWUhKHODIQVSPlQGxXClEj+63m+cqZskw+ESmeZg==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.24.tgz",
+      "integrity": "sha512-J6H4R1nvr3uBTqD/EeIPAskrBtET4WFfNhpFySr2xW7bVZOXpQfPjrLSIx65jcNjBmLXzWq8QFLdVoGxiGG/SA==",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.19",
-        "@aws-sdk/nested-clients": "^3.996.9",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/nested-clients": "^3.996.14",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -622,29 +622,29 @@
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.1008.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.1008.0.tgz",
-      "integrity": "sha512-JPjsKAYpuaDwmeE2WvrrfTb27FYa6kIe0gj1JCazHWGteQ6LDycBddsDsRSgq2MfqAqdcHnrgnfGzY1+j8AxoQ==",
+      "version": "3.1017.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.1017.0.tgz",
+      "integrity": "sha512-TPtd9zq7ePVWDYDYLMYcCNk+TNYFdb3pKzwQWRHq9d6OfVKqBFa5GjsKjcCWACw77S0UhGW6KPOOK3/ts9CTmA==",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.1008.0",
-        "@aws-sdk/core": "^3.973.19",
-        "@aws-sdk/credential-provider-cognito-identity": "^3.972.12",
-        "@aws-sdk/credential-provider-env": "^3.972.17",
-        "@aws-sdk/credential-provider-http": "^3.972.19",
-        "@aws-sdk/credential-provider-ini": "^3.972.19",
-        "@aws-sdk/credential-provider-login": "^3.972.19",
-        "@aws-sdk/credential-provider-node": "^3.972.20",
-        "@aws-sdk/credential-provider-process": "^3.972.17",
-        "@aws-sdk/credential-provider-sso": "^3.972.19",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.19",
-        "@aws-sdk/nested-clients": "^3.996.9",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/config-resolver": "^4.4.10",
-        "@smithy/core": "^3.23.9",
-        "@smithy/credential-provider-imds": "^4.2.11",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/client-cognito-identity": "3.1017.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/credential-provider-cognito-identity": "^3.972.17",
+        "@aws-sdk/credential-provider-env": "^3.972.22",
+        "@aws-sdk/credential-provider-http": "^3.972.24",
+        "@aws-sdk/credential-provider-ini": "^3.972.24",
+        "@aws-sdk/credential-provider-login": "^3.972.24",
+        "@aws-sdk/credential-provider-node": "^3.972.25",
+        "@aws-sdk/credential-provider-process": "^3.972.22",
+        "@aws-sdk/credential-provider-sso": "^3.972.24",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.24",
+        "@aws-sdk/nested-clients": "^3.996.14",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.12",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -710,13 +710,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.7.tgz",
-      "integrity": "sha512-aHQZgztBFEpDU1BB00VWCIIm85JjGjQW1OG9+98BdmaOpguJvzmXBGbnAiYcciCd+IS4e9BEq664lhzGnWJHgQ==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -738,12 +738,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.7.tgz",
-      "integrity": "sha512-LXhiWlWb26txCU1vcI9PneESSeRp/RYY/McuM4SpdrimQR5NgwaPb4VJCadVeuGWgh6QmqZ6rAKSoL1ob16W6w==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -751,14 +751,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.7.tgz",
-      "integrity": "sha512-l2VQdcBcYLzIzykCHtXlbpiVCZ94/xniLIkAj0jpnpjY4xlgZx7f56Ypn+uV1y3gG0tNVytJqo3K9bfMFee7SQ==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.8.tgz",
+      "integrity": "sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/types": "^3.973.6",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -805,17 +805,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.20.tgz",
-      "integrity": "sha512-3kNTLtpUdeahxtnJRnj/oIdLAUdzTfr9N40KtxNhtdrq+Q1RPMdCJINRXq37m4t5+r3H70wgC3opW46OzFcZYA==",
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.25.tgz",
+      "integrity": "sha512-QxiMPofvOt8SwSynTOmuZfvvPM1S9QfkESBxB22NMHTRXCJhR5BygLl8IXfC4jELiisQgwsgUby21GtXfX3f/g==",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.19",
-        "@aws-sdk/types": "^3.973.5",
-        "@aws-sdk/util-endpoints": "^3.996.4",
-        "@smithy/core": "^3.23.9",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-retry": "^4.2.11",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@smithy/core": "^3.23.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-retry": "^4.2.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -823,46 +823,46 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.9.tgz",
-      "integrity": "sha512-+RpVtpmQbbtzFOKhMlsRcXM/3f1Z49qTOHaA8gEpHOYruERmog6f2AUtf/oTRLCWjR9H2b3roqryV/hI7QMW8w==",
+      "version": "3.996.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.14.tgz",
+      "integrity": "sha512-fSESKvh1VbfjtV3QMnRkCPZWkUbQof6T/DOpiLp33yP2wA+rbwwnZeG3XT3Ekljgw2I8X4XaQPnw+zSR8yxJ5Q==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.19",
-        "@aws-sdk/middleware-host-header": "^3.972.7",
-        "@aws-sdk/middleware-logger": "^3.972.7",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
-        "@aws-sdk/middleware-user-agent": "^3.972.20",
-        "@aws-sdk/region-config-resolver": "^3.972.7",
-        "@aws-sdk/types": "^3.973.5",
-        "@aws-sdk/util-endpoints": "^3.996.4",
-        "@aws-sdk/util-user-agent-browser": "^3.972.7",
-        "@aws-sdk/util-user-agent-node": "^3.973.6",
-        "@smithy/config-resolver": "^4.4.10",
-        "@smithy/core": "^3.23.9",
-        "@smithy/fetch-http-handler": "^5.3.13",
-        "@smithy/hash-node": "^4.2.11",
-        "@smithy/invalid-dependency": "^4.2.11",
-        "@smithy/middleware-content-length": "^4.2.11",
-        "@smithy/middleware-endpoint": "^4.4.23",
-        "@smithy/middleware-retry": "^4.4.40",
-        "@smithy/middleware-serde": "^4.2.12",
-        "@smithy/middleware-stack": "^4.2.11",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/node-http-handler": "^4.4.14",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/smithy-client": "^4.12.3",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.11",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.25",
+        "@aws-sdk/region-config-resolver": "^3.972.9",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.11",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.27",
+        "@smithy/middleware-retry": "^4.4.44",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.39",
-        "@smithy/util-defaults-mode-node": "^4.2.42",
-        "@smithy/util-endpoints": "^3.3.2",
-        "@smithy/util-middleware": "^4.2.11",
-        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-defaults-mode-browser": "^4.3.43",
+        "@smithy/util-defaults-mode-node": "^4.2.47",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -871,14 +871,14 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.7.tgz",
-      "integrity": "sha512-/Ev/6AI8bvt4HAAptzSjThGUMjcWaX3GX8oERkB0F0F9x2dLSBdgFDiyrRz3i0u0ZFZFQ1b28is4QhyqXTUsVA==",
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.9.tgz",
+      "integrity": "sha512-eQ+dFU05ZRC/lC2XpYlYSPlXtX3VT8sn5toxN2Fv7EXlMoA2p9V7vUBKqHunfD4TRLpxUq8Y8Ol/nCqiv327Ng==",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/config-resolver": "^4.4.10",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -903,16 +903,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1008.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1008.0.tgz",
-      "integrity": "sha512-TulwlHQBWcJs668kNUDMZHN51DeLrDsYT59Ux4a/nbvr025gM6HjKJJ3LvnZccam7OS/ZKUVkWomCneRQKJbBg==",
+      "version": "3.1015.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1015.0.tgz",
+      "integrity": "sha512-3OSD4y110nisRhHzFOjoEeHU4GQL4KpzkX9PxzWaiZe0Yg2+thZKM0Pn9DjYwezH5JYfh/K++xK/SE0IHGrmCQ==",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.19",
-        "@aws-sdk/nested-clients": "^3.996.9",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/property-provider": "^4.2.11",
-        "@smithy/shared-ini-file-loader": "^4.4.6",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/core": "^3.973.24",
+        "@aws-sdk/nested-clients": "^3.996.14",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -920,11 +920,11 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.5.tgz",
-      "integrity": "sha512-hl7BGwDCWsjH8NkZfx+HgS7H2LyM2lTMAI7ba9c8O0KqdBLTdNJivsHpqjg9rNlAlPyREb6DeDRXUl0s8uFdmQ==",
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -944,14 +944,14 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.4.tgz",
-      "integrity": "sha512-Hek90FBmd4joCFj+Vc98KLJh73Zqj3s2W56gjAcTkrNLMDI5nIFkG9YpfcJiVI1YlE2Ne1uOQNe+IgQ/Vz2XRA==",
+      "version": "3.996.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.11",
-        "@smithy/util-endpoints": "^3.3.2",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-endpoints": "^3.3.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -970,25 +970,25 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.7.tgz",
-      "integrity": "sha512-7SJVuvhKhMF/BkNS1n0QAJYgvEwYbK2QLKBrzDiwQGiTRU6Yf1f3nehTzm/l21xdAOtWSfp2uWSddPnP2ZtsVw==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.6.tgz",
-      "integrity": "sha512-iF7G0prk7AvmOK64FcLvc/fW+Ty1H+vttajL7PvJFReU8urMxfYmynTTuFKDTA76Wgpq3FzTPKwabMQIXQHiXQ==",
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.11.tgz",
+      "integrity": "sha512-1qdXbXo2s5MMLpUvw00284LsbhtlQ4ul7Zzdn5n+7p4WVgCMLqhxImpHIrjSoc72E/fyc4Wq8dLtUld2Gsh+lA==",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.20",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/middleware-user-agent": "^3.972.25",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
         "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -1005,12 +1005,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.10.tgz",
-      "integrity": "sha512-OnejAIVD+CxzyAUrVic7lG+3QRltyja9LoNqCE/1YVs8ichoTbJlVSaZ9iSMcnHLyzrSNtvaOGjSDRP+d/ouFA==",
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.15.tgz",
+      "integrity": "sha512-PxMRlCFNiQnke9YR29vjFQwz4jq+6Q04rOVFeTDR2K7Qpv9h9FOWOxG+zJjageimYbWqE3bTuLjmryWHAWbvaA==",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
-        "fast-xml-parser": "5.4.1",
+        "@smithy/types": "^4.13.1",
+        "fast-xml-parser": "5.5.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4224,9 +4224,9 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.11",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.11.tgz",
-      "integrity": "sha512-YxFiiG4YDAtX7WMN7RuhHZLeTmRRAOyCbr+zB8e3AQzHPnUhS8zXjB1+cniPVQI3xbWsQPM0X2aaIkO/ME0ymw==",
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.13.tgz",
+      "integrity": "sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.12",
         "@smithy/types": "^4.13.1",
@@ -4240,9 +4240,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.11",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.11.tgz",
-      "integrity": "sha512-952rGf7hBRnhUIaeLp6q4MptKW8sPFe5VvkoZ5qIzFAtx6c/QZ/54FS3yootsyUSf9gJX/NBqEBNdNR7jMIlpQ==",
+      "version": "3.23.12",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.12.tgz",
+      "integrity": "sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w==",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.12",
         "@smithy/types": "^4.13.1",
@@ -4250,7 +4250,7 @@
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-stream": "^4.5.19",
+        "@smithy/util-stream": "^4.5.20",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
@@ -4453,12 +4453,12 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.25",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.25.tgz",
-      "integrity": "sha512-dqjLwZs2eBxIUG6Qtw8/YZ4DvzHGIf0DA18wrgtfP6a50UIO7e2nY0FPdcbv5tVJKqWCCU5BmGMOUwT7Puan+A==",
+      "version": "4.4.27",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.27.tgz",
+      "integrity": "sha512-T3TFfUgXQlpcg+UdzcAISdZpj4Z+XECZ/cefgA6wLBd6V4lRi0svN2hBouN/be9dXQ31X4sLWz3fAQDf+nt6BA==",
       "dependencies": {
-        "@smithy/core": "^3.23.11",
-        "@smithy/middleware-serde": "^4.2.14",
+        "@smithy/core": "^3.23.12",
+        "@smithy/middleware-serde": "^4.2.15",
         "@smithy/node-config-provider": "^4.3.12",
         "@smithy/shared-ini-file-loader": "^4.4.7",
         "@smithy/types": "^4.13.1",
@@ -4471,14 +4471,14 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.42",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.42.tgz",
-      "integrity": "sha512-vbwyqHRIpIZutNXZpLAozakzamcINaRCpEy1MYmK6xBeW3xN+TyPRA123GjXnuxZIjc9848MRRCugVMTXxC4Eg==",
+      "version": "4.4.44",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.44.tgz",
+      "integrity": "sha512-Y1Rav7m5CFRPQyM4CI0koD/bXjyjJu3EQxZZhtLGD88WIrBrQ7kqXM96ncd6rYnojwOo/u9MXu57JrEvu/nLrA==",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.12",
         "@smithy/protocol-http": "^5.3.12",
         "@smithy/service-error-classification": "^4.2.12",
-        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/smithy-client": "^4.12.7",
         "@smithy/types": "^4.13.1",
         "@smithy/util-middleware": "^4.2.12",
         "@smithy/util-retry": "^4.2.12",
@@ -4490,11 +4490,11 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.14.tgz",
-      "integrity": "sha512-+CcaLoLa5apzSRtloOyG7lQvkUw2ZDml3hRh4QiG9WyEPfW5Ke/3tPOPiPjUneuT59Tpn8+c3RVaUvvkkwqZwg==",
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.15.tgz",
+      "integrity": "sha512-ExYhcltZSli0pgAKOpQQe1DLFBLryeZ22605y/YS+mQpdNWekum9Ujb/jMKfJKgjtz1AZldtwA/wCYuKJgjjlg==",
       "dependencies": {
-        "@smithy/core": "^3.23.11",
+        "@smithy/core": "^3.23.12",
         "@smithy/protocol-http": "^5.3.12",
         "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
@@ -4530,9 +4530,9 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.16",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.16.tgz",
-      "integrity": "sha512-ULC8UCS/HivdCB3jhi+kLFYe4B5gxH2gi9vHBfEIiRrT2jfKiZNiETJSlzRtE6B26XbBHjPtc8iZKSNqMol9bw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.0.tgz",
+      "integrity": "sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==",
       "dependencies": {
         "@smithy/abort-controller": "^4.2.12",
         "@smithy/protocol-http": "^5.3.12",
@@ -4635,16 +4635,16 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.5.tgz",
-      "integrity": "sha512-UqwYawyqSr/aog8mnLnfbPurS0gi4G7IYDcD28cUIBhsvWs1+rQcL2IwkUQ+QZ7dibaoRzhNF99fAQ9AUcO00w==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.7.tgz",
+      "integrity": "sha512-q3gqnwml60G44FECaEEsdQMplYhDMZYCtYhMCzadCnRnnHIobZJjegmdoUo6ieLQlPUzvrMdIJUpx6DoPmzANQ==",
       "dependencies": {
-        "@smithy/core": "^3.23.11",
-        "@smithy/middleware-endpoint": "^4.4.25",
+        "@smithy/core": "^3.23.12",
+        "@smithy/middleware-endpoint": "^4.4.27",
         "@smithy/middleware-stack": "^4.2.12",
         "@smithy/protocol-http": "^5.3.12",
         "@smithy/types": "^4.13.1",
-        "@smithy/util-stream": "^4.5.19",
+        "@smithy/util-stream": "^4.5.20",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4734,12 +4734,12 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.41",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.41.tgz",
-      "integrity": "sha512-M1w1Ux0rSVvBOxIIiqbxvZvhnjQ+VUjJrugtORE90BbadSTH+jsQL279KRL3Hv0w69rE7EuYkV/4Lepz/NBW9g==",
+      "version": "4.3.43",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.43.tgz",
+      "integrity": "sha512-Qd/0wCKMaXxev/z00TvNzGCH2jlKKKxXP1aDxB6oKwSQthe3Og2dMhSayGCnsma1bK/kQX1+X7SMP99t6FgiiQ==",
       "dependencies": {
         "@smithy/property-provider": "^4.2.12",
-        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/smithy-client": "^4.12.7",
         "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
@@ -4748,15 +4748,15 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.44",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.44.tgz",
-      "integrity": "sha512-YPze3/lD1KmWuZsl9JlfhcgGLX7AXhSoaCDtiPntUjNW5/YY0lOHjkcgxyE9x/h5vvS1fzDifMGjzqnNlNiqOQ==",
+      "version": "4.2.47",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.47.tgz",
+      "integrity": "sha512-qSRbYp1EQ7th+sPFuVcVO05AE0QH635hycdEXlpzIahqHHf2Fyd/Zl+8v0XYMJ3cgDVPa0lkMefU7oNUjAP+DQ==",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/config-resolver": "^4.4.13",
         "@smithy/credential-provider-imds": "^4.2.12",
         "@smithy/node-config-provider": "^4.3.12",
         "@smithy/property-provider": "^4.2.12",
-        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/smithy-client": "^4.12.7",
         "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
@@ -4814,12 +4814,12 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.19",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.19.tgz",
-      "integrity": "sha512-v4sa+3xTweL1CLO2UP0p7tvIMH/Rq1X4KKOxd568mpe6LSLMQCnDHs4uv7m3ukpl3HvcN2JH6jiCS0SNRXKP/w==",
+      "version": "4.5.20",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.20.tgz",
+      "integrity": "sha512-4yXLm5n/B5SRBR2p8cZ90Sbv4zL4NKsgxdzCzp/83cXw2KxLEumt5p+GAVyRNZgQOSrzXn9ARpO0lUe8XSlSDw==",
       "dependencies": {
         "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/node-http-handler": "^4.4.16",
+        "@smithy/node-http-handler": "^4.5.0",
         "@smithy/types": "^4.13.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-buffer-from": "^4.2.2",
@@ -8226,9 +8226,9 @@
       ]
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.3.tgz",
-      "integrity": "sha512-1o60KoFw2+LWKQu3IdcfcFlGTW4dpqEWmjhYec6H82AYZU2TVBXep6tMl8Z1Y+wM+ZrzCwe3BZ9Vyd9N2rIvmg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
       "funding": [
         {
           "type": "github",
@@ -8240,9 +8240,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
-      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
       "funding": [
         {
           "type": "github",
@@ -8250,8 +8250,9 @@
         }
       ],
       "dependencies": {
-        "fast-xml-builder": "^1.0.0",
-        "strnum": "^2.1.2"
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -11070,9 +11071,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
-      "integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
       "funding": [
         {
           "type": "github",
@@ -12614,9 +12615,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
-      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
       "funding": [
         {
           "type": "github",

--- a/collab/package-lock.json
+++ b/collab/package-lock.json
@@ -21,7 +21,7 @@
         "@babel/preset-react": "^7.28.5",
         "@emotion/react": "^11.14.0",
         "@guardian/eslint-config-typescript": "^10.0.1",
-        "@guardian/pan-domain-node": "^1.2.0",
+        "@guardian/pan-domain-node": "^1.2.3",
         "@guardian/tsconfig": "^0.3.1",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",

--- a/collab/package.json
+++ b/collab/package.json
@@ -27,7 +27,7 @@
     "@babel/preset-react": "^7.28.5",
     "@emotion/react": "^11.14.0",
     "@guardian/eslint-config-typescript": "^10.0.1",
-    "@guardian/pan-domain-node": "^1.2.0",
+    "@guardian/pan-domain-node": "^1.2.3",
     "@guardian/tsconfig": "^0.3.1",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",

--- a/collab/package.json
+++ b/collab/package.json
@@ -15,8 +15,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@aws-sdk/client-secrets-manager": "^3.995.0",
-    "@aws-sdk/credential-providers": "^3.995.0",
+    "@aws-sdk/client-secrets-manager": "^3.1017.0",
+    "@aws-sdk/credential-providers": "^3.1017.0",
     "cors": "^2.8.5",
     "express": "^4.22.1",
     "postgres": "^3.4.4",


### PR DESCRIPTION
## What does this change?
Bump AWS vulnerabilities `3.995.0 -> 3.1017.0` to address high runtime vulnerabilities.

## How has this change been tested?
Tested locally

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
